### PR TITLE
Add basic migrations and cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Virtual environment
+venv/
+
+# Django related
+*.sqlite3
+
+# Environment variables
+.env
+
+# Logs
+*.log
+

--- a/tenantsaas/customers/migrations/0001_initial.py
+++ b/tenantsaas/customers/migrations/0001_initial.py
@@ -1,0 +1,30 @@
+from django.db import migrations, models
+import django.db.models.deletion
+from django_tenants.postgresql_backend.base import _check_schema_name
+
+class Migration(migrations.Migration):
+    initial = True
+
+    dependencies = []
+
+    operations = [
+        migrations.CreateModel(
+            name='Tenant',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('schema_name', models.CharField(max_length=63, unique=True, db_index=True, validators=[_check_schema_name])),
+                ('name', models.CharField(max_length=100)),
+            ],
+            options={'app_label': 'customers'},
+        ),
+        migrations.CreateModel(
+            name='Domain',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('domain', models.CharField(max_length=253, unique=True, db_index=True)),
+                ('is_primary', models.BooleanField(default=True, db_index=True)),
+                ('tenant', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='domains', to='customers.tenant')),
+            ],
+            options={'app_label': 'customers'},
+        ),
+    ]

--- a/tenantsaas/customers/models.py
+++ b/tenantsaas/customers/models.py
@@ -7,5 +7,9 @@ class Tenant(TenantMixin):
     class Meta:
         app_label = 'customers'
 
+    def __str__(self):
+        return self.name
+
 class Domain(DomainMixin):
-    pass
+    def __str__(self):
+        return self.domain


### PR DESCRIPTION
## Summary
- add `.gitignore`
- add `__str__` definitions for models
- create initial migration for `customers` app

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_685c6842d39c832e986b303bb178db02

## Summary by Sourcery

Set up initial database schema and clean up the customers app by adding migrations, model string representations, and a .gitignore file

Enhancements:
- Add __str__ methods to Tenant and Domain models for readable representations
- Create initial migration to define Tenant and Domain tables

Chores:
- Add .gitignore to exclude untracked files