### PR TITLE
Update settings env configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ This repository contains a minimal Django project configured for multi-tenant ap
    pip install -r tenantsaas/requirements.txt
    ```
 
-3. Configure your database settings in `tenantsaas/tenantsaas/settings.py`. For a typical local setup you will need a database name, user and password with permissions to create schemas.
+3. Configure your environment variables. At minimum set your database credentials
+   (``POSTGRES_DB``, ``POSTGRES_USER`` and ``POSTGRES_PASSWORD``). You can also
+   customise ``DEBUG``, ``ALLOWED_HOSTS`` and ``CSRF_TRUSTED_ORIGINS`` to suit
+   your deployment. See ``tenantsaas/tenantsaas/settings.py`` for all supported
+   options.
 
 ## Running the application
 

--- a/tenantsaas/tenantsaas/settings.py
+++ b/tenantsaas/tenantsaas/settings.py
@@ -12,9 +12,22 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = os.environ.get('SECRET_KEY', 'django-insecure-rag+joyrb9yir*@l@i5e$bao8wb!&66_04%2)oh1i40j5*6h)a')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+# Reads DEBUG from the environment, defaulting to True for development.
+DEBUG = os.environ.get('DEBUG', 'True') == 'True'
 
-ALLOWED_HOSTS = []
+# Allow configuring allowed hosts via a comma separated environment variable.
+_hosts = os.environ.get('ALLOWED_HOSTS')
+if _hosts:
+    ALLOWED_HOSTS = [h.strip() for h in _hosts.split(',') if h.strip()]
+else:
+    ALLOWED_HOSTS = []
+
+# Optionally specify trusted origins for CSRF using a comma separated list.
+CSRF_TRUSTED_ORIGINS = [
+    o.strip()
+    for o in os.environ.get('CSRF_TRUSTED_ORIGINS', '').split(',')
+    if o.strip()
+]
 
 
 # Application definition


### PR DESCRIPTION
## Summary
- improve README instructions for configuring settings
- allow settings to read DEBUG, ALLOWED_HOSTS and CSRF_TRUSTED_ORIGINS from env vars

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement asgiref==3.8.1)*

------
https://chatgpt.com/codex/tasks/task_b_685c6af67254832ebb5055f846f0b1ad

## Summary by Sourcery

Enable environment-based configuration for debug and security settings and update documentation accordingly

New Features:
- Read DEBUG value from environment variables with a default of True
- Load ALLOWED_HOSTS from a comma-separated environment variable
- Load CSRF_TRUSTED_ORIGINS from a comma-separated environment variable

Documentation:
- Improve README to guide users in setting environment variables for database credentials and optional DEBUG, ALLOWED_HOSTS, and CSRF_TRUSTED_ORIGINS