### PR TITLE
Add customer signup page

### DIFF
--- a/saasapp/customers/forms.py
+++ b/saasapp/customers/forms.py
@@ -1,0 +1,13 @@
+from django import forms
+from django.contrib.auth.forms import UserCreationForm
+from django.contrib.auth import get_user_model
+
+
+class CustomerSignupForm(UserCreationForm):
+    name = forms.CharField(max_length=100)
+    domain = forms.CharField(max_length=255)
+    schema_name = forms.CharField(max_length=63, required=False)
+
+    class Meta(UserCreationForm.Meta):
+        model = get_user_model()
+        fields = UserCreationForm.Meta.fields + ("name", "domain", "schema_name")

--- a/saasapp/saasapp/urls.py
+++ b/saasapp/saasapp/urls.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 from django.urls import path, include
-from customers.views import create_customer, approve_customer, list_tenants, pending_requests
+from customers.views import create_customer, approve_customer, list_tenants, pending_requests, signup
 from core.views import home, dashboard
 
 urlpatterns = [
@@ -10,6 +10,7 @@ urlpatterns = [
     path('approve/<int:pk>/', approve_customer, name='approve_customer'),
     path('api/tenants/', list_tenants, name='list_tenants'),
     path('api/requests/', pending_requests, name='pending_requests'),
+    path('signup/', signup, name='signup'),
     path('dashboard/', dashboard, name='dashboard'),
     path('', home, name='home'),
 ]

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,7 +7,8 @@
     {% if user.is_authenticated %}
         Logged in as {{ user.username }} | <a href="{% url 'logout' %}">Logout</a>
     {% else %}
-        <a href="{% url 'login' %}">Login</a>
+        <a href="{% url 'login' %}">Login</a> |
+        <a href="{% url 'signup' %}">Sign Up</a>
     {% endif %}
     <hr>
     {% block content %}{% endblock %}

--- a/templates/registration/signup.html
+++ b/templates/registration/signup.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Sign Up</h2>
+<form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit">Sign Up</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- create `CustomerSignupForm`
- add signup view with tenant request creation
- add signup URL and update base template
- include signup page template

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_b_685c7d5c1750832ea3c57751698254be

## Summary by Sourcery

Implement a new customer signup flow including form, view, URL, template, and tenant request creation

New Features:
- Add CustomerSignupForm to collect user credentials, tenant name, domain, and optional schema name
- Implement signup view to process the form, create a CustomerRequest, auto-login the user, and redirect to home
- Register the signup URL (/signup/) and include it in the project’s URL patterns

Enhancements:
- Add signup page template and update the base template with a Sign Up link in the navigation