### PR TITLE
Add service and task management

### DIFF
--- a/saasapp/core/forms.py
+++ b/saasapp/core/forms.py
@@ -1,0 +1,14 @@
+from django import forms
+from .models import Service, Task
+
+
+class ServiceForm(forms.ModelForm):
+    class Meta:
+        model = Service
+        fields = ["name", "description"]
+
+
+class TaskForm(forms.ModelForm):
+    class Meta:
+        model = Task
+        fields = ["name", "service", "completed"]

--- a/saasapp/core/migrations/0001_initial.py
+++ b/saasapp/core/migrations/0001_initial.py
@@ -1,0 +1,35 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+    initial = True
+
+    dependencies = []
+
+    operations = [
+        migrations.CreateModel(
+            name='Item',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('name', models.CharField(max_length=100)),
+            ],
+        ),
+        migrations.CreateModel(
+            name='Service',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('name', models.CharField(max_length=100)),
+                ('description', models.TextField(blank=True)),
+            ],
+        ),
+        migrations.CreateModel(
+            name='Task',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('name', models.CharField(max_length=100)),
+                ('completed', models.BooleanField(default=False)),
+                ('service', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='tasks', to='core.service')),
+            ],
+        ),
+    ]

--- a/saasapp/core/models.py
+++ b/saasapp/core/models.py
@@ -1,7 +1,25 @@
 from django.db import models
 
+
 class Item(models.Model):
     name = models.CharField(max_length=100)
 
     def __str__(self):
+        return self.name
+
+
+class Service(models.Model):
+    name = models.CharField(max_length=100)
+    description = models.TextField(blank=True)
+
+    def __str__(self) -> str:  # pragma: no cover - simple string rep
+        return self.name
+
+
+class Task(models.Model):
+    name = models.CharField(max_length=100)
+    service = models.ForeignKey(Service, on_delete=models.CASCADE, related_name="tasks")
+    completed = models.BooleanField(default=False)
+
+    def __str__(self) -> str:  # pragma: no cover - simple string rep
         return self.name

--- a/saasapp/core/views.py
+++ b/saasapp/core/views.py
@@ -1,6 +1,11 @@
-from django.shortcuts import render
+from django.shortcuts import render, redirect
 from django.contrib.auth.decorators import login_required, user_passes_test
-from customers.models import Tenant, Domain, CustomerRequest
+from customers.models import Tenant, CustomerRequest
+from django_tenants.utils import tenant_context
+
+from .models import Service, Task
+from .forms import ServiceForm, TaskForm
+
 
 @login_required
 def home(request):
@@ -17,3 +22,59 @@ def dashboard(request):
     tenants = Tenant.objects.all()
     requests = CustomerRequest.objects.filter(approved=False)
     return render(request, "dashboard.html", {"tenants": tenants, "requests": requests})
+
+
+@login_required
+def service_list(request):
+    services = Service.objects.all()
+    return render(request, "service_list.html", {"services": services})
+
+
+@login_required
+def service_create(request):
+    if request.method == "POST":
+        form = ServiceForm(request.POST)
+        if form.is_valid():
+            form.save()
+            return redirect("service_list")
+    else:
+        form = ServiceForm()
+    return render(request, "service_form.html", {"form": form})
+
+
+@login_required
+def task_list(request):
+    tasks = Task.objects.select_related("service").all()
+    return render(request, "task_list.html", {"tasks": tasks})
+
+
+@login_required
+def task_create(request):
+    if request.method == "POST":
+        form = TaskForm(request.POST)
+        if form.is_valid():
+            form.save()
+            return redirect("task_list")
+    else:
+        form = TaskForm()
+    return render(request, "task_form.html", {"form": form})
+
+
+@user_passes_test(is_core)
+def all_services(request):
+    records = []
+    for tenant in Tenant.objects.all():
+        with tenant_context(tenant):
+            for service in Service.objects.all():
+                records.append({"tenant": tenant, "service": service})
+    return render(request, "all_services.html", {"records": records})
+
+
+@user_passes_test(is_core)
+def all_tasks(request):
+    records = []
+    for tenant in Tenant.objects.all():
+        with tenant_context(tenant):
+            for task in Task.objects.select_related("service").all():
+                records.append({"tenant": tenant, "task": task})
+    return render(request, "all_tasks.html", {"records": records})

--- a/saasapp/saasapp/urls.py
+++ b/saasapp/saasapp/urls.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 from django.urls import path, include
 from customers.views import create_customer, approve_customer, list_tenants, pending_requests, signup
-from core.views import home, dashboard
+from core.views import home, dashboard, service_list, service_create, task_list, task_create, all_services, all_tasks
 
 urlpatterns = [
     path('admin/', admin.site.urls),
@@ -12,5 +12,11 @@ urlpatterns = [
     path('api/requests/', pending_requests, name='pending_requests'),
     path('signup/', signup, name='signup'),
     path('dashboard/', dashboard, name='dashboard'),
+    path('services/', service_list, name='service_list'),
+    path('services/new/', service_create, name='service_create'),
+    path('tasks/', task_list, name='task_list'),
+    path('tasks/new/', task_create, name='task_create'),
+    path('all_services/', all_services, name='all_services'),
+    path('all_tasks/', all_tasks, name='all_tasks'),
     path('', home, name='home'),
 ]

--- a/templates/all_services.html
+++ b/templates/all_services.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>All Services</h2>
+<ul>
+{% for rec in records %}
+    <li>{{ rec.tenant.schema_name }} - {{ rec.service.name }}</li>
+{% empty %}
+    <li>No services.</li>
+{% endfor %}
+</ul>
+{% endblock %}

--- a/templates/all_tasks.html
+++ b/templates/all_tasks.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>All Tasks</h2>
+<ul>
+{% for rec in records %}
+    <li>{{ rec.tenant.schema_name }} - {{ rec.task.name }} ({{ rec.task.service.name }}) {% if rec.task.completed %}(done){% endif %}</li>
+{% empty %}
+    <li>No tasks.</li>
+{% endfor %}
+</ul>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,7 +5,16 @@
 </head>
 <body>
     {% if user.is_authenticated %}
-        Logged in as {{ user.username }} | <a href="{% url 'logout' %}">Logout</a>
+        Logged in as {{ user.username }} |
+        <a href="{% url 'home' %}">Home</a> |
+        <a href="{% url 'service_list' %}">Services</a> |
+        <a href="{% url 'task_list' %}">Tasks</a>
+        {% if user.is_core %}
+            | <a href="{% url 'all_services' %}">All Services</a>
+            | <a href="{% url 'all_tasks' %}">All Tasks</a>
+            | <a href="{% url 'dashboard' %}">Dashboard</a>
+        {% endif %}
+        | <a href="{% url 'logout' %}">Logout</a>
     {% else %}
         <a href="{% url 'login' %}">Login</a> |
         <a href="{% url 'signup' %}">Sign Up</a>

--- a/templates/service_form.html
+++ b/templates/service_form.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>New Service</h2>
+<form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit">Save</button>
+</form>
+{% endblock %}

--- a/templates/service_list.html
+++ b/templates/service_list.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Services</h2>
+<a href="{% url 'service_create' %}">Add Service</a>
+<ul>
+{% for s in services %}
+    <li>{{ s.name }} - {{ s.description }}</li>
+{% empty %}
+    <li>No services.</li>
+{% endfor %}
+</ul>
+{% endblock %}

--- a/templates/task_form.html
+++ b/templates/task_form.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>New Task</h2>
+<form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit">Save</button>
+</form>
+{% endblock %}

--- a/templates/task_list.html
+++ b/templates/task_list.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Tasks</h2>
+<a href="{% url 'task_create' %}">Add Task</a>
+<ul>
+{% for t in tasks %}
+    <li>{{ t.name }} ({{ t.service.name }}) {% if t.completed %}(done){% endif %}</li>
+{% empty %}
+    <li>No tasks.</li>
+{% endfor %}
+</ul>
+{% endblock %}


### PR DESCRIPTION
## Summary
- allow tenants to manage services and tasks
- enable core users to view all tenant services and tasks
- wire up views and URLs
- expose navigation links
- add initial migrations

## Testing
- `python -m django --version` *(fails: No module named django)*

------
https://chatgpt.com/codex/tasks/task_b_685c8650e17c832e90d7e4162c279115

## Summary by Sourcery

Add tenant-scoped service and task management including listing and creation views, templates, forms, and URL routes, plus core-user endpoints to aggregate across tenants.

New Features:
- Introduce Service and Task models with name, description, relationship, and completion flag
- Provide tenant-scoped views and forms for listing and creating services and tasks
- Add core-user views to aggregate and display all tenant services and tasks

Enhancements:
- Expose navigation links for services, tasks, and core dashboards in the base template

Build:
- Add initial migration for Service and Task models

Chores:
- Wire up URL paths for service and task management endpoints