### PR TITLE
Add static assets and admin registrations

### DIFF
--- a/saasapp/core/admin.py
+++ b/saasapp/core/admin.py
@@ -1,0 +1,6 @@
+from django.contrib import admin
+from .models import Item, Service, Task
+
+admin.site.register(Item)
+admin.site.register(Service)
+admin.site.register(Task)

--- a/saasapp/customers/admin.py
+++ b/saasapp/customers/admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
-from .models import Tenant, Domain
+from .models import Tenant, Domain, CustomerRequest
 
 admin.site.register(Tenant)
 admin.site.register(Domain)
+admin.site.register(CustomerRequest)

--- a/saasapp/saasapp/settings.py
+++ b/saasapp/saasapp/settings.py
@@ -95,6 +95,7 @@ USE_I18N = True
 USE_TZ = True
 
 STATIC_URL = 'static/'
+STATICFILES_DIRS = [os.path.join(BASE_DIR, '../static')]
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 TENANT_MODEL = 'customers.Tenant'

--- a/saasapp/shared/admin.py
+++ b/saasapp/shared/admin.py
@@ -1,0 +1,7 @@
+from django.contrib import admin
+from django.contrib.auth.admin import UserAdmin
+from .models import CoreUser
+
+@admin.register(CoreUser)
+class CoreUserAdmin(UserAdmin):
+    pass

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,0 +1,19 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 20px;
+}
+nav {
+    margin-bottom: 20px;
+}
+h1, h2, h3 {
+    color: #333;
+}
+ul {
+    list-style-type: none;
+    padding: 0;
+}
+li {
+    margin-bottom: 5px;
+}
+
+.container { max-width: 800px; margin: auto; }

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1,0 +1,3 @@
+document.addEventListener('DOMContentLoaded', function () {
+    console.log('App loaded');
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,25 +1,32 @@
+{% load static %}
 <!DOCTYPE html>
 <html>
 <head>
     <title>Django SaaS</title>
+    <link rel="stylesheet" href="{% static 'css/style.css' %}">
+    <script src="{% static 'js/app.js' %}" defer></script>
 </head>
 <body>
-    {% if user.is_authenticated %}
-        Logged in as {{ user.username }} |
-        <a href="{% url 'home' %}">Home</a> |
-        <a href="{% url 'service_list' %}">Services</a> |
-        <a href="{% url 'task_list' %}">Tasks</a>
-        {% if user.is_core %}
-            | <a href="{% url 'all_services' %}">All Services</a>
-            | <a href="{% url 'all_tasks' %}">All Tasks</a>
-            | <a href="{% url 'dashboard' %}">Dashboard</a>
+    <nav>
+        {% if user.is_authenticated %}
+            Logged in as {{ user.username }} |
+            <a href="{% url 'home' %}">Home</a> |
+            <a href="{% url 'service_list' %}">Services</a> |
+            <a href="{% url 'task_list' %}">Tasks</a>
+            {% if user.is_core %}
+                | <a href="{% url 'all_services' %}">All Services</a>
+                | <a href="{% url 'all_tasks' %}">All Tasks</a>
+                | <a href="{% url 'dashboard' %}">Dashboard</a>
+            {% endif %}
+            | <a href="{% url 'logout' %}">Logout</a>
+        {% else %}
+            <a href="{% url 'login' %}">Login</a> |
+            <a href="{% url 'signup' %}">Sign Up</a>
         {% endif %}
-        | <a href="{% url 'logout' %}">Logout</a>
-    {% else %}
-        <a href="{% url 'login' %}">Login</a> |
-        <a href="{% url 'signup' %}">Sign Up</a>
-    {% endif %}
+    </nav>
     <hr>
-    {% block content %}{% endblock %}
+    <div class="container">
+        {% block content %}{% endblock %}
+    </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- style pages via `style.css` and load with `base.html`
- include small JS file and hook up in the base template
- register models in admin for `customers`, `core`, and `shared`
- expose project static folder via `STATICFILES_DIRS`

## Testing
- `python3 manage.py check` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_b_685ca64c1ba8832e951515717132aed9

## Summary by Sourcery

Integrate static assets and admin configurations across the project.

Enhancements:
- Add CSS and JavaScript static files and reference them in the base template.
- Wrap navigation in a <nav> element and enclose content in a container in base.html.
- Expose the project’s static folder via STATICFILES_DIRS in settings.
- Register application models in the Django admin for customers, core, and shared apps.