### PR TITLE
Implement client model and styled task/service pages

### DIFF
--- a/saasapp/core/forms.py
+++ b/saasapp/core/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from .models import Service, Task
+from .models import Service, Task, Client
 
 
 class ServiceForm(forms.ModelForm):
@@ -12,3 +12,9 @@ class TaskForm(forms.ModelForm):
     class Meta:
         model = Task
         fields = ["name", "service", "completed"]
+
+
+class ClientForm(forms.ModelForm):
+    class Meta:
+        model = Client
+        fields = ["name", "email"]

--- a/saasapp/core/migrations/0003_client_and_task_user.py
+++ b/saasapp/core/migrations/0003_client_and_task_user.py
@@ -1,0 +1,27 @@
+from django.db import migrations, models
+import django.db.models.deletion
+from django.conf import settings
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0002_customer'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Client',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('name', models.CharField(max_length=100)),
+                ('email', models.EmailField(blank=True, max_length=254)),
+            ],
+        ),
+        migrations.AddField(
+            model_name='task',
+            name='user',
+            field=models.ForeignKey(default=1, on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL),
+            preserve_default=False,
+        ),
+    ]

--- a/saasapp/core/models.py
+++ b/saasapp/core/models.py
@@ -29,9 +29,20 @@ class Service(models.Model):
         return self.name
 
 
+class Client(models.Model):
+    """Simple client record stored per tenant."""
+
+    name = models.CharField(max_length=100)
+    email = models.EmailField(blank=True)
+
+    def __str__(self) -> str:  # pragma: no cover - simple string rep
+        return self.name
+
+
 class Task(models.Model):
     name = models.CharField(max_length=100)
     service = models.ForeignKey(Service, on_delete=models.CASCADE, related_name="tasks")
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
     completed = models.BooleanField(default=False)
 
     def __str__(self) -> str:  # pragma: no cover - simple string rep

--- a/saasapp/customers/views.py
+++ b/saasapp/customers/views.py
@@ -82,6 +82,8 @@ def pending_requests(request):
 
 def signup(request):
     """Allow a new user to sign up and request a customer tenant."""
+    if getattr(request, "tenant", None) and request.tenant.schema_name != "public":
+        return HttpResponseForbidden("Sign up only allowed on public site")
     if request.method == "POST":
         form = CustomerSignupForm(request.POST)
         if form.is_valid():

--- a/saasapp/saasapp/urls.py
+++ b/saasapp/saasapp/urls.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 from django.urls import path, include
 from customers.views import create_customer, approve_customer, list_tenants, pending_requests, signup
-from core.views import home, dashboard, service_list, service_create, task_list, task_create, all_services, all_tasks
+from core.views import home, dashboard, service_list, service_create, task_list, task_create, all_services, all_tasks, client_list, client_create
 
 urlpatterns = [
     path('admin/', admin.site.urls),
@@ -16,6 +16,8 @@ urlpatterns = [
     path('services/new/', service_create, name='service_create'),
     path('tasks/', task_list, name='task_list'),
     path('tasks/new/', task_create, name='task_create'),
+    path('clients/', client_list, name='client_list'),
+    path('clients/new/', client_create, name='client_create'),
     path('all_services/', all_services, name='all_services'),
     path('all_tasks/', all_tasks, name='all_tasks'),
     path('', home, name='home'),

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,12 +1,16 @@
 body {
     font-family: Arial, sans-serif;
     margin: 20px;
+    background-color: #f0f2f5;
 }
 nav {
     margin-bottom: 20px;
-    background-color: #f8f8f8;
+    background-color: #343a40;
     padding: 10px;
     border-radius: 4px;
+    color: #fff;
+    display: flex;
+    gap: 10px;
 }
 h1 {
     margin-top: 0;
@@ -30,10 +34,32 @@ li {
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
+.service-box {
+    border: 1px solid #ddd;
+    padding: 10px;
+    border-radius: 4px;
+    margin-bottom: 10px;
+    background-color: #fafafa;
+}
+
+.table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.table th, .table td {
+    border: 1px solid #ddd;
+    padding: 8px;
+}
+
+.table th {
+    background-color: #f2f2f2;
+}
+
 nav a {
     margin-right: 10px;
     text-decoration: none;
-    color: #007bff;
+    color: #fff;
 }
 
 nav a:hover {

--- a/templates/base.html
+++ b/templates/base.html
@@ -14,7 +14,8 @@
             Logged in as {{ user.username }} |
             <a href="{% url 'home' %}">Home</a> |
             <a href="{% url 'service_list' %}">Services</a> |
-            <a href="{% url 'task_list' %}">Tasks</a>
+            <a href="{% url 'task_list' %}">Tasks</a> |
+            <a href="{% url 'client_list' %}">Clients</a>
             {% if user.is_core %}
                 | <a href="{% url 'all_services' %}">All Services</a>
                 | <a href="{% url 'all_tasks' %}">All Tasks</a>

--- a/templates/client_form.html
+++ b/templates/client_form.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>New Client</h2>
+<form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit">Save</button>
+</form>
+{% endblock %}

--- a/templates/client_list.html
+++ b/templates/client_list.html
@@ -1,0 +1,13 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Clients</h2>
+<a href="{% url 'client_create' %}">Add Client</a>
+<table class="table">
+    <tr><th>Name</th><th>Email</th></tr>
+    {% for c in clients %}
+        <tr><td>{{ c.name }}</td><td>{{ c.email }}</td></tr>
+    {% empty %}
+        <tr><td colspan="2">No clients.</td></tr>
+    {% endfor %}
+</table>
+{% endblock %}

--- a/templates/service_list.html
+++ b/templates/service_list.html
@@ -2,11 +2,14 @@
 {% block content %}
 <h2>Services</h2>
 <a href="{% url 'service_create' %}">Add Service</a>
-<ul>
+<div class="services">
 {% for s in services %}
-    <li>{{ s.name }} - {{ s.description }}</li>
+    <div class="service-box">
+        <h3>{{ s.name }}</h3>
+        <p>{{ s.description }}</p>
+    </div>
 {% empty %}
-    <li>No services.</li>
+    <p>No services.</p>
 {% endfor %}
-</ul>
+</div>
 {% endblock %}

--- a/templates/task_list.html
+++ b/templates/task_list.html
@@ -2,11 +2,16 @@
 {% block content %}
 <h2>Tasks</h2>
 <a href="{% url 'task_create' %}">Add Task</a>
-<ul>
+<table class="table">
+    <tr><th>Name</th><th>Service</th><th>Status</th></tr>
 {% for t in tasks %}
-    <li>{{ t.name }} ({{ t.service.name }}) {% if t.completed %}(done){% endif %}</li>
+    <tr>
+        <td>{{ t.name }}</td>
+        <td>{{ t.service.name }}</td>
+        <td>{% if t.completed %}done{% else %}pending{% endif %}</td>
+    </tr>
 {% empty %}
-    <li>No tasks.</li>
+    <tr><td colspan="3">No tasks.</td></tr>
 {% endfor %}
-</ul>
+</table>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add a Client model and migrations
- associate tasks with the creating user
- filter task list for public schema users
- disallow signup from tenant schemas
- create client list and form views/templates
- add navigation link to clients
- restyle pages with boxes and tables

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685cb7666a10832ea5241d28aac5e596

## Summary by Sourcery

Implement client management and enhance task handling with user associations and UI styling

New Features:
- Introduce Client model with CRUD views, forms, templates, and routes

Bug Fixes:
- Prevent tenant-schema user signup, allowing it only on the public schema

Enhancements:
- Associate tasks with their creator and filter public-schema task lists by user
- Restyle service, task, and client pages with boxes, tables, and updated CSS
- Add Clients navigation link to the base template

Chores:
- Add migration to create Client model and to add user field on Task