### PR TITLE
Implement FOIA request workflow

### DIFF
--- a/saasapp/core/admin.py
+++ b/saasapp/core/admin.py
@@ -1,7 +1,9 @@
 from django.contrib import admin
-from .models import Item, Service, Task, Customer
+from .models import Item, Service, Task, Customer, Membership, FoiaRequest
 
 admin.site.register(Item)
 admin.site.register(Service)
 admin.site.register(Task)
 admin.site.register(Customer)
+admin.site.register(Membership)
+admin.site.register(FoiaRequest)

--- a/saasapp/core/forms.py
+++ b/saasapp/core/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from .models import Service, Task, Client
+from .models import Service, Task, Client, FoiaRequest, Membership
 
 
 class ServiceForm(forms.ModelForm):
@@ -18,3 +18,20 @@ class ClientForm(forms.ModelForm):
     class Meta:
         model = Client
         fields = ["name", "email"]
+
+
+class FoiaRequestForm(forms.ModelForm):
+    class Meta:
+        model = FoiaRequest
+        fields = ["description"]
+
+
+class FoiaAssignForm(forms.Form):
+    assignee = forms.ModelChoiceField(queryset=Membership.objects.none())
+
+    def __init__(self, *args, **kwargs):
+        tenant = kwargs.pop("tenant")
+        super().__init__(*args, **kwargs)
+        self.fields["assignee"].queryset = Membership.objects.filter(
+            tenant=tenant, role=Membership.STAFF
+        ).select_related("user")

--- a/saasapp/core/migrations/0004_membership_and_foia.py
+++ b/saasapp/core/migrations/0004_membership_and_foia.py
@@ -1,0 +1,38 @@
+from django.db import migrations, models
+import django.db.models.deletion
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0003_client_and_task_user'),
+        ('customers', '0002_remove_tenant_auto_create_schema_and_more'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Membership',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('role', models.CharField(max_length=20)),
+                ('tenant', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='customers.tenant')),
+                ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
+            ],
+        ),
+        migrations.CreateModel(
+            name='FoiaRequest',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('description', models.TextField()),
+                ('accepted', models.BooleanField(default=False)),
+                ('assigned_to', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='assigned_foia_requests', to=settings.AUTH_USER_MODEL)),
+                ('resident', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='foia_requests', to=settings.AUTH_USER_MODEL)),
+            ],
+        ),
+        migrations.AlterUniqueTogether(
+            name='membership',
+            unique_together={('user', 'tenant')},
+        ),
+    ]

--- a/saasapp/core/models.py
+++ b/saasapp/core/models.py
@@ -47,3 +47,46 @@ class Task(models.Model):
 
     def __str__(self) -> str:  # pragma: no cover - simple string rep
         return self.name
+
+
+class Membership(models.Model):
+    """Links a user to a tenant with a role."""
+
+    ADMIN = "admin"
+    STAFF = "staff"
+    RESIDENT = "resident"
+    ROLE_CHOICES = [
+        (ADMIN, "Admin"),
+        (STAFF, "Staff"),
+        (RESIDENT, "Resident"),
+    ]
+
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
+    tenant = models.ForeignKey(Tenant, on_delete=models.CASCADE)
+    role = models.CharField(max_length=20, choices=ROLE_CHOICES)
+
+    class Meta:
+        unique_together = ["user", "tenant"]
+
+    def __str__(self) -> str:  # pragma: no cover - simple string rep
+        return f"{self.user.username} - {self.role}"
+
+
+class FoiaRequest(models.Model):
+    """Request created by a resident."""
+
+    description = models.TextField()
+    resident = models.ForeignKey(
+        settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name="foia_requests"
+    )
+    accepted = models.BooleanField(default=False)
+    assigned_to = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="assigned_foia_requests",
+    )
+
+    def __str__(self) -> str:  # pragma: no cover - simple string rep
+        return f"FOIA #{self.pk}"

--- a/saasapp/customers/views.py
+++ b/saasapp/customers/views.py
@@ -7,7 +7,7 @@ from django.shortcuts import render, redirect
 
 from django_tenants.utils import schema_context, tenant_context
 from .models import Tenant, Domain, CustomerRequest
-from core.models import Customer
+from core.models import Customer, Membership
 from .forms import CustomerSignupForm
 
 
@@ -29,6 +29,7 @@ def approve_customer(request, pk):
 
     with tenant_context(tenant):
         Customer.objects.create(tenant=tenant, name=req.name, owner=req.user)
+        Membership.objects.create(user=req.user, tenant=tenant, role=Membership.ADMIN)
     req.approved = True
     req.save()
     return JsonResponse({"status": "approved", "tenant": tenant.schema_name})

--- a/saasapp/saasapp/settings.py
+++ b/saasapp/saasapp/settings.py
@@ -104,3 +104,4 @@ DATABASE_ROUTERS = ['django_tenants.routers.TenantSyncRouter']
 
 AUTH_USER_MODEL = 'shared.CoreUser'
 LOGIN_REDIRECT_URL = '/'
+LOGOUT_REDIRECT_URL = '/'

--- a/saasapp/saasapp/urls.py
+++ b/saasapp/saasapp/urls.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 from django.urls import path, include
 from customers.views import create_customer, approve_customer, list_tenants, pending_requests, signup
-from core.views import home, dashboard, service_list, service_create, task_list, task_create, all_services, all_tasks, client_list, client_create
+from core.views import home, dashboard, service_list, service_create, task_list, task_create, all_services, all_tasks, client_list, client_create, foia_request_create, foia_request_list, foia_request_accept, foia_request_assign
 
 urlpatterns = [
     path('admin/', admin.site.urls),
@@ -16,6 +16,10 @@ urlpatterns = [
     path('services/new/', service_create, name='service_create'),
     path('tasks/', task_list, name='task_list'),
     path('tasks/new/', task_create, name='task_create'),
+    path('foia/new/', foia_request_create, name='foia_create'),
+    path('foia/', foia_request_list, name='foia_list'),
+    path('foia/<int:pk>/accept/', foia_request_accept, name='foia_accept'),
+    path('foia/<int:pk>/assign/', foia_request_assign, name='foia_assign'),
     path('clients/', client_list, name='client_list'),
     path('clients/new/', client_create, name='client_create'),
     path('all_services/', all_services, name='all_services'),

--- a/templates/base.html
+++ b/templates/base.html
@@ -15,7 +15,9 @@
             <a href="{% url 'home' %}">Home</a> |
             <a href="{% url 'service_list' %}">Services</a> |
             <a href="{% url 'task_list' %}">Tasks</a> |
-            <a href="{% url 'client_list' %}">Clients</a>
+            <a href="{% url 'client_list' %}">Clients</a> |
+            <a href="{% url 'foia_create' %}">New FOIA</a> |
+            <a href="{% url 'foia_list' %}">FOIA Requests</a>
             {% if user.is_core %}
                 | <a href="{% url 'all_services' %}">All Services</a>
                 | <a href="{% url 'all_tasks' %}">All Tasks</a>

--- a/templates/foia_assign_form.html
+++ b/templates/foia_assign_form.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Assign FOIA {{ foia.pk }}</h2>
+<form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit">Assign</button>
+</form>
+{% endblock %}

--- a/templates/foia_request_form.html
+++ b/templates/foia_request_form.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>New FOIA Request</h2>
+<form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit">Submit</button>
+</form>
+{% endblock %}

--- a/templates/foia_request_list.html
+++ b/templates/foia_request_list.html
@@ -1,0 +1,23 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>FOIA Requests</h2>
+<table>
+    <tr>
+        <th>ID</th><th>Resident</th><th>Accepted</th><th>Assigned To</th><th>Actions</th>
+    </tr>
+    {% for foia in foias %}
+    <tr>
+        <td>{{ foia.pk }}</td>
+        <td>{{ foia.resident.username }}</td>
+        <td>{{ foia.accepted }}</td>
+        <td>{{ foia.assigned_to.username|default:'-' }}</td>
+        <td>
+            {% if not foia.accepted %}
+                <a href="{% url 'foia_accept' foia.pk %}">Accept</a>
+            {% endif %}
+            <a href="{% url 'foia_assign' foia.pk %}">Assign</a>
+        </td>
+    </tr>
+    {% endfor %}
+</table>
+{% endblock %}


### PR DESCRIPTION
## Summary
- allow logout redirection
- add membership and foia request models
- expose admin workflows for FOIA requests
- wire views, forms and templates for FOIA tasks
- register new models in admin

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_b_685cba00ee08832e9127ef14573329e9

## Summary by Sourcery

Implement a complete FOIA request workflow by introducing new models for role and request management, wiring up corresponding views, forms, templates, and URL routes for resident submissions and admin processing, and configuring logout redirection.

New Features:
- Enable residents to submit FOIA requests
- Enable admins to list, accept, and assign FOIA requests

Enhancements:
- Add Membership and FoiaRequest models with migrations and register them in Django admin
- Add views, forms, templates, and URL routes to support the FOIA request workflow
- Introduce LOGOUT_REDIRECT_URL for logout redirection
- Auto-create Membership with admin role upon customer approval