### PR TITLE
Implement auto-localhost domains and new roles

### DIFF
--- a/saasapp/core/forms.py
+++ b/saasapp/core/forms.py
@@ -33,5 +33,5 @@ class FoiaAssignForm(forms.Form):
         tenant = kwargs.pop("tenant")
         super().__init__(*args, **kwargs)
         self.fields["assignee"].queryset = Membership.objects.filter(
-            tenant=tenant, role=Membership.STAFF
+            tenant=tenant, role=Membership.MEMBER
         ).select_related("user")

--- a/saasapp/core/migrations/0005_update_membership_roles.py
+++ b/saasapp/core/migrations/0005_update_membership_roles.py
@@ -1,0 +1,17 @@
+from django.db import migrations
+
+
+def rename_staff_to_member(apps, schema_editor):
+    Membership = apps.get_model("core", "Membership")
+    Membership.objects.filter(role="staff").update(role="member")
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0004_membership_and_foia"),
+    ]
+
+    operations = [
+        migrations.RunPython(rename_staff_to_member, migrations.RunPython.noop),
+    ]

--- a/saasapp/core/models.py
+++ b/saasapp/core/models.py
@@ -53,11 +53,16 @@ class Membership(models.Model):
     """Links a user to a tenant with a role."""
 
     ADMIN = "admin"
-    STAFF = "staff"
+    MEMBER = "member"
+    APPROVER = "approver"
+    PUBLISHER = "publisher"
     RESIDENT = "resident"
+
     ROLE_CHOICES = [
         (ADMIN, "Admin"),
-        (STAFF, "Staff"),
+        (MEMBER, "Member"),
+        (APPROVER, "Approver"),
+        (PUBLISHER, "Publisher"),
         (RESIDENT, "Resident"),
     ]
 

--- a/saasapp/customers/forms.py
+++ b/saasapp/customers/forms.py
@@ -5,7 +5,7 @@ from django.contrib.auth import get_user_model
 
 class CustomerSignupForm(UserCreationForm):
     name = forms.CharField(max_length=100)
-    domain = forms.CharField(max_length=255)
+    domain = forms.CharField(max_length=255, required=False)
     schema_name = forms.CharField(max_length=63, required=False)
 
     class Meta(UserCreationForm.Meta):

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -12,7 +12,7 @@
 <h3>Tenants</h3>
 <ul>
 {% for t in tenants %}
-    <li>{{ t.name }} ({{ t.domain_url }})</li>
+    <li>{{ t.name }} ({{ t.domains.first.domain }})</li>
 {% endfor %}
 </ul>
 {% endblock %}


### PR DESCRIPTION
## Summary
- extend membership roles with member, approver and publisher
- make tenant domain optional and default to `<name>.localhost`
- show tenant domain on the dashboard
- update tenant approval and signup flows for the new domain logic
- include a data migration to rename existing staff roles to member

## Testing
- `python -m py_compile saasapp/core/forms.py saasapp/core/models.py saasapp/customers/forms.py saasapp/customers/views.py`
- `source venv/Scripts/activate && python saasapp/manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_b_685cbfcf3068832e959038d29de884f1

## Summary by Sourcery

Introduce auto-generated localhost domains, extend membership roles, and update related flows and data to reflect the new logic.

New Features:
- Make tenant domain optional and default to <schema_name>.localhost in customer approval, signup, and creation flows
- Add new membership roles: member, approver, and publisher

Enhancements:
- Update forms, views, and template to support the auto-localhost domain logic and remove domain requirement
- Show each tenant’s primary domain on the dashboard
- Adjust assignee queryset to use the new Member role

Chores:
- Add a data migration to rename existing staff roles to member