### PR TITLE
Add resident signup flow and style tweaks

### DIFF
--- a/saasapp/core/forms.py
+++ b/saasapp/core/forms.py
@@ -1,4 +1,6 @@
 from django import forms
+from django.contrib.auth.forms import UserCreationForm
+from django.contrib.auth import get_user_model
 from .models import Service, Task, Client, FoiaRequest, Membership
 
 
@@ -35,3 +37,11 @@ class FoiaAssignForm(forms.Form):
         self.fields["assignee"].queryset = Membership.objects.filter(
             tenant=tenant, role=Membership.MEMBER
         ).select_related("user")
+
+
+class ResidentSignupForm(UserCreationForm):
+    """Sign up form for residents within a tenant."""
+
+    class Meta(UserCreationForm.Meta):
+        model = get_user_model()
+        fields = UserCreationForm.Meta.fields

--- a/saasapp/saasapp/urls.py
+++ b/saasapp/saasapp/urls.py
@@ -2,7 +2,23 @@ from django.contrib import admin
 from django.urls import path, include
 from django.contrib.auth import views as auth_views
 from customers.views import create_customer, approve_customer, list_tenants, pending_requests, signup
-from core.views import home, dashboard, service_list, service_create, task_list, task_create, all_services, all_tasks, client_list, client_create, foia_request_create, foia_request_list, foia_request_accept, foia_request_assign
+from core.views import (
+    home,
+    dashboard,
+    service_list,
+    service_create,
+    task_list,
+    task_create,
+    all_services,
+    all_tasks,
+    client_list,
+    client_create,
+    foia_request_create,
+    foia_request_list,
+    foia_request_accept,
+    foia_request_assign,
+    resident_signup,
+)
 
 urlpatterns = [
     path('admin/', admin.site.urls),
@@ -22,6 +38,7 @@ urlpatterns = [
     path('foia/', foia_request_list, name='foia_list'),
     path('foia/<int:pk>/accept/', foia_request_accept, name='foia_accept'),
     path('foia/<int:pk>/assign/', foia_request_assign, name='foia_assign'),
+    path('resident_signup/', resident_signup, name='resident_signup'),
     path('clients/', client_list, name='client_list'),
     path('clients/new/', client_create, name='client_create'),
     path('all_services/', all_services, name='all_services'),

--- a/templates/base.html
+++ b/templates/base.html
@@ -29,6 +29,9 @@
                 {% else %}
                     <li class="nav-item"><a class="nav-link" href="{% url 'login' %}">Login</a></li>
                     <li class="nav-item"><a class="nav-link" href="{% url 'signup' %}">Sign Up</a></li>
+                    {% if request.tenant and request.tenant.schema_name != 'public' %}
+                        <li class="nav-item"><a class="nav-link" href="{% url 'resident_signup' %}">Resident Sign Up</a></li>
+                    {% endif %}
                 {% endif %}
                 </ul>
             </div>

--- a/templates/foia_assign_form.html
+++ b/templates/foia_assign_form.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2>Assign FOIA {{ foia.pk }}</h2>
-<form method="post">
+<form method="post" class="mb-3">
     {% csrf_token %}
     {{ form.as_p }}
     <button type="submit">Assign</button>

--- a/templates/foia_request_list.html
+++ b/templates/foia_request_list.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2>FOIA Requests</h2>
-<table>
+<table class="table">
     <tr>
         <th>ID</th><th>Resident</th><th>Accepted</th><th>Assigned To</th><th>Actions</th>
     </tr>

--- a/templates/registration/resident_signup.html
+++ b/templates/registration/resident_signup.html
@@ -1,9 +1,9 @@
 {% extends 'base.html' %}
 {% block content %}
-<h2>New FOIA Request</h2>
-<form method="post" class="mb-3">
+<h2>Resident Sign Up</h2>
+<form method="post">
     {% csrf_token %}
     {{ form.as_p }}
-    <button type="submit">Submit</button>
+    <button type="submit">Sign Up</button>
 </form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- allow residents to create their own accounts
- wire new resident signup view into URLs
- link to resident signup from the base nav bar
- apply Bootstrap styling to FOIA templates

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_685daea75548832ebea6cecb6e252dd5

## Summary by Sourcery

Add a tenant-scoped resident signup flow and enhance FOIA templates with Bootstrap styling.

New Features:
- Introduce resident signup flow with form, view, URL and nav link allowing users to self-register on tenant sites

Enhancements:
- Apply Bootstrap classes to FOIA request forms and tables for consistent styling