### PR TITLE
Improve logout behavior

### DIFF
--- a/saasapp/core/views.py
+++ b/saasapp/core/views.py
@@ -42,9 +42,9 @@ def is_resident(user, tenant):
 
 
 class LogoutView(DjangoLogoutView):
-    """Allow logging out via GET requests."""
+    """Require POST requests to log out."""
 
-    http_method_names = ["get"]
+    http_method_names = ["post"]
 
 
 @user_passes_test(is_core)

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -94,3 +94,16 @@ input[type="submit"]:hover {
 form {
     margin-top: 10px;
 }
+
+.link-button {
+    background: none;
+    border: none;
+    padding: 0;
+    color: inherit;
+    font: inherit;
+    cursor: pointer;
+}
+
+.link-button:hover {
+    text-decoration: underline;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -23,7 +23,12 @@
                         <li><a href="{% url 'all_tasks' %}">All Tasks</a></li>
                         <li><a href="{% url 'dashboard' %}">Dashboard</a></li>
                     {% endif %}
-                    <li><a href="{% url 'logout' %}">Logout</a></li>
+                    <li>
+                        <form action="{% url 'logout' %}" method="post" style="display:inline;">
+                            {% csrf_token %}
+                            <button type="submit" class="link-button">Logout</button>
+                        </form>
+                    </li>
                 {% else %}
                     <li><a href="{% url 'login' %}">Login</a></li>
                     <li><a href="{% url 'signup' %}">Sign Up</a></li>


### PR DESCRIPTION
## Summary
- require POST for logout requests
- show logout button as a form
- style logout button to look like a link

## Testing
- `python saasapp/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_b_685dc8968e18832e8a311f52bca8541e

## Summary by Sourcery

Require POST for logout requests and update the logout UI to use a styled form button that appears as a link

Enhancements:
- Enforce POST-only logout in LogoutView
- Replace logout hyperlink with an inline POST form in base template
- Add and apply .link-button CSS class to style logout button as a link