### PR TITLE
Fix logout recursion

### DIFF
--- a/saasapp/core/views.py
+++ b/saasapp/core/views.py
@@ -5,7 +5,7 @@ from django.contrib.auth.views import LogoutView as DjangoLogoutView
 from django.http import HttpResponseForbidden, HttpResponseBadRequest
 from customers.models import Tenant, CustomerRequest
 from django_tenants.utils import tenant_context
-from django.contrib.auth import logout
+from django.contrib.auth import logout as auth_logout
 
 from .models import Service, Task, Customer, Client, FoiaRequest, Membership
 from .forms import (
@@ -43,7 +43,8 @@ def is_resident(user, tenant):
 
 
 def logout(request):
-    logout(request)
+    auth_logout(request)
+    return redirect("home")
 
 
 @user_passes_test(is_core)


### PR DESCRIPTION
## Summary
- fix recursion in custom `logout` view by calling django's logout

## Testing
- `python saasapp/manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*
- `python3 -m pip install -r saasapp/requirements.txt` *(fails: Could not find a version that satisfies the requirement Django==5.1.8)*

------
https://chatgpt.com/codex/tasks/task_b_685de6238400832eba6b19cd851aac99

## Summary by Sourcery

Fix the custom logout view to call Django's logout function and redirect users to the home page.

Bug Fixes:
- Fix infinite recursion in custom logout view by invoking django.contrib.auth.logout instead of the view function.

Enhancements:
- Redirect users to the home page after logging out.