### PR TITLE
Auto-create main tenant for superuser

### DIFF
--- a/saasapp/shared/__init__.py
+++ b/saasapp/shared/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'shared.apps.SharedConfig'

--- a/saasapp/shared/apps.py
+++ b/saasapp/shared/apps.py
@@ -4,3 +4,7 @@ from django.apps import AppConfig
 class SharedConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'shared'
+
+    def ready(self):
+        # Import signal handlers
+        from . import signals  # noqa: F401

--- a/saasapp/shared/signals.py
+++ b/saasapp/shared/signals.py
@@ -1,0 +1,39 @@
+from django.conf import settings
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from django_tenants.utils import schema_context, tenant_context
+
+from customers.models import Tenant, Domain
+from core.models import Customer, Membership
+
+
+@receiver(post_save, sender=settings.AUTH_USER_MODEL)
+def create_superuser_membership(sender, instance, created, **kwargs):
+    """Ensure superusers get admin membership on the main tenant."""
+    if not created or not instance.is_superuser:
+        return
+
+    schema_name = 'main'
+    tenant_name = 'localhost'
+    domain_name = 'localhost'
+
+    # Create tenant and domain on the public schema
+    with schema_context('public'):
+        tenant, created_tenant = Tenant.objects.get_or_create(
+            schema_name=schema_name,
+            defaults={'name': tenant_name},
+        )
+        if created_tenant:
+            Domain.objects.create(domain=domain_name, tenant=tenant, is_primary=True)
+
+    # Create customer and membership inside the tenant schema
+    with tenant_context(tenant):
+        Customer.objects.get_or_create(
+            tenant=tenant,
+            defaults={'name': tenant_name, 'owner': instance},
+        )
+        Membership.objects.get_or_create(
+            user=instance,
+            tenant=tenant,
+            defaults={'role': Membership.ADMIN},
+        )


### PR DESCRIPTION
## Summary
- load signals in `shared` app
- create `signals.py` to ensure a `Tenant` and `Domain` named `main` are created whenever a superuser is created
- automatically assign the new superuser an admin `Membership`

## Testing
- `pip install -r saasapp/requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_b_685e0d25b0f4832eb10372b142a04aa1

## Summary by Sourcery

Register shared app signals and automatically provision a default tenant and domain for new superusers, granting them admin membership.

New Features:
- Load the signals module in the shared app's ready hook
- Add a post_save signal to auto-create a 'main' tenant and its primary domain when a superuser is created
- Automatically grant new superusers an admin membership on the 'main' tenant